### PR TITLE
- add dropped-css-class on Wall-of-Thoughts page

### DIFF
--- a/app/wallofthoughts/page.jsx
+++ b/app/wallofthoughts/page.jsx
@@ -39,8 +39,8 @@ const WallOfThoughts = () => {
 			<Styles.PrimaryHeader>
 				Your thoughts are very important to us. Please share them with us
 			</Styles.PrimaryHeader>
-			<Styles.NotesContainer className='flex-wrap'>
-				<Styles.NotesChild>
+			<Styles.NotesContainer className='flex-wrap m-4'>
+				<Styles.NotesChild className="">
 					<Styles.Card color={selectedColor} className="h-[23rem]">
 						<CardHeader>
 							<Styles.CardTitle>


### PR DESCRIPTION
# before
<img width="1327" alt="Screenshot 2024-05-30 at 10 42 20" src="https://github.com/babaygt/safe-bike/assets/7362718/8deb5403-bfb6-4d37-b5c6-503cb6c116e6">

# after
<img width="1225" alt="Screenshot 2024-05-30 at 10 43 23" src="https://github.com/babaygt/safe-bike/assets/7362718/567c61d0-ec9e-402a-b6d4-505f72cc3ac7">
